### PR TITLE
Replace the Markdown 3.4 deprecated and removed objects

### DIFF
--- a/mdx_unimoji.py
+++ b/mdx_unimoji.py
@@ -124,7 +124,7 @@ class UnimojiExtension(Extension):
                 aliases[a] = emoticon
         self.config['aliases'] = [aliases, '']
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         import re
         RE = r'((?<=\s)|(?<=^))(?P<emoticon>%s)(?=\s|$)' % '|'.join(map(re.escape, self.getConfig('aliases')))
         md.inlinePatterns['emoji'] = UnimojiPattern(RE, md, self)

--- a/mdx_unimoji.py
+++ b/mdx_unimoji.py
@@ -127,7 +127,7 @@ class UnimojiExtension(Extension):
     def extendMarkdown(self, md):
         import re
         RE = r'((?<=\s)|(?<=^))(?P<emoticon>%s)(?=\s|$)' % '|'.join(map(re.escape, self.getConfig('aliases')))
-        md.inlinePatterns['emoji'] = UnimojiPattern(RE, md, self)
+        md.inlinePatterns.register(UnimojiPattern(RE, md, self), 'emoji', 200)
 
 
 class UnimojiPattern(Pattern):

--- a/mdx_unimoji.py
+++ b/mdx_unimoji.py
@@ -52,7 +52,7 @@ HF!
 """
 from __future__ import unicode_literals
 from markdown import Extension
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 from markdown.inlinepatterns import Pattern
 
 class UnimojiExtension(Extension):


### PR DESCRIPTION
These commits ensure you can now use this extension with the 3.4 version of Markdown.
[A lot of deprecated objects were removed](https://python-markdown.github.io/change_log/release-3.4/#previously-deprecated-objects-have-been-removed), and they are now fix.